### PR TITLE
handler for mysql 8.0.19 duplicate key error update

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ default_language_version:
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: ebc15addedad713c86ef18ae9632c88e187dd0af  # v3.1.0
+    rev: 9136088a246768144165fcc3ecc3d31bb686920a # v3.3.0
     hooks:
       - id: trailing-whitespace
       # Replaces or checks mixed line ending

--- a/oslo_db/sqlalchemy/exc_filters.py
+++ b/oslo_db/sqlalchemy/exc_filters.py
@@ -120,6 +120,12 @@ def _default_dupe_key_error(integrity_error, match, engine_name,
     N columns - (IntegrityError) duplicate key value violates unique
                constraint "name_of_our_constraint"
 
+    mysql since 8.0.19:
+    1 column - (IntegrityError) (1062, "Duplicate entry 'value_of_c1' for key
+               'table_name.name_of_constraint_tbl0c1'")
+    N columns - (IntegrityError) (1062, "Duplicate entry 'values joined
+               with -' for key 'table_name.name_of_constraint_tbl0c10c20cn'")
+
     mysql+mysqldb:
     1 column - (IntegrityError) (1062, "Duplicate entry 'value_of_c1' for key
                'c1'")
@@ -145,6 +151,9 @@ def _default_dupe_key_error(integrity_error, match, engine_name,
     if not columns.startswith(uniqbase):
         if engine_name == "postgresql":
             columns = [columns[columns.index("_") + 1:columns.rindex("_")]]
+        elif (engine_name == "mysql") and \
+             (uniqbase in str(columns.split("0")[:1])):
+            columns = columns.split("0")[1:]
         else:
             columns = [columns]
     else:

--- a/oslo_db/tests/sqlalchemy/test_exc_filters.py
+++ b/oslo_db/tests/sqlalchemy/test_exc_filters.py
@@ -821,6 +821,14 @@ class TestDuplicate(TestsExceptionFilter):
             expected_value='2'
         )
 
+    def test_mysql_duplicate_entry_key_start_with_tablename(self):
+        self._run_dupe_constraint_test(
+            "mysql",
+            "1062 (23000): Duplicate entry '2' for key 'tbl.uniq_tbl0b'",
+            expected_columns=['b'],
+            expected_value='2'
+        )
+
     def test_mysql_binary(self):
         self._run_dupe_constraint_test(
             "mysql",
@@ -836,6 +844,24 @@ class TestDuplicate(TestsExceptionFilter):
             "''\\\\x8A$\\\\x8D\\\\xA6\"s\\\\x8E!,' "
             "for key 'PRIMARY'\')",
             expected_columns=['PRIMARY'],
+            expected_value="'\\\\x8A$\\\\x8D\\\\xA6\"s\\\\x8E!,"
+        )
+
+    def test_mysql_duplicate_entry_key_start_with_tablename_binary(self):
+        self._run_dupe_constraint_test(
+            "mysql",
+            "(1062, \'Duplicate entry "
+            "\\\'\\\\x8A$\\\\x8D\\\\xA6\"s\\\\x8E\\\' "
+            "for key \\\'tbl.uniq_tbl0c1\\\'\')",
+            expected_columns=['c1'],
+            expected_value="\\\\x8A$\\\\x8D\\\\xA6\"s\\\\x8E"
+        )
+        self._run_dupe_constraint_test(
+            "mysql",
+            "(1062, \'Duplicate entry "
+            "''\\\\x8A$\\\\x8D\\\\xA6\"s\\\\x8E!,' "
+            "for key 'tbl.uniq_tbl0c1'\')",
+            expected_columns=['c1'],
             expected_value="'\\\\x8A$\\\\x8D\\\\xA6\"s\\\\x8E!,"
         )
 


### PR DESCRIPTION
In mysql 8.0.19 , Duplicate key error information was extended to inlude the table name of the key.

Previously, duplicate key error information included only the key value and key name.
Here,Added handler for mysql 8.0.19 duplicate key error update

Change-Id: I832ca2f115ed1d2b1471d7b00ddf36cdeda41ad1

Closes-Bug:1896916 (https://bugs.launchpad.net/oslo.db/+bug/1896916)